### PR TITLE
Add Money support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
   "require": {
     "php": ">=5.5.9",
     "ramsey/uuid": "~2.8",
-    "respect/validation": "1.0.3"
+    "respect/validation": "1.0.3",
+    "moneyphp/money": "^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "5.2.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,86 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "813c1081952cef233a31bdd8f1ab8f17",
-    "content-hash": "6601fc8a872e585b9f7c0eb144f3eac3",
+    "content-hash": "250706056119426e9c948b681870d89f",
     "packages": [
+        {
+            "name": "moneyphp/money",
+            "version": "v3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/moneyphp/money.git",
+                "reference": "295c5135af2aedba535587e3d9daa30c176964b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/moneyphp/money/zipball/295c5135af2aedba535587e3d9daa30c176964b6",
+                "reference": "295c5135af2aedba535587e3d9daa30c176964b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "cache/taggable-cache": "^0.4.0",
+                "ext-bcmath": "*",
+                "ext-gmp": "*",
+                "ext-intl": "*",
+                "florianv/swap": "^3.0",
+                "henrikbjorn/phpspec-code-coverage": "^2.0.2",
+                "moneyphp/iso-currencies": "^1.0",
+                "php-http/message": "^1.4",
+                "php-http/mock-client": "^0.3.3",
+                "phpspec/phpspec": "^2.5",
+                "phpunit/phpunit": "^4.5",
+                "psr/cache": "^1.0",
+                "sllh/php-cs-fixer-styleci-bridge": "^2.1"
+            },
+            "suggest": {
+                "ext-bcmath": "Calculate without integer limits",
+                "ext-gmp": "Calculate without integer limits",
+                "ext-intl": "Format Money objects with intl",
+                "florianv/swap": "Exchange rates library for PHP",
+                "psr/cache-implementation": "Used for Currency caching"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Money\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Verraes",
+                    "email": "mathias@verraes.net",
+                    "homepage": "http://verraes.net"
+                },
+                {
+                    "name": "Frederik Bosch",
+                    "email": "f.bosch@genkgo.nl"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagi-kazar@gmail.com"
+                }
+            ],
+            "description": "PHP implementation of Fowler's Money pattern",
+            "homepage": "http://verraes.net/2011/04/fowler-money-pattern-in-php/",
+            "keywords": [
+                "Value Object",
+                "money",
+                "vo"
+            ],
+            "time": "2017-03-22T22:24:40+00:00"
+        },
         {
             "name": "paragonie/random_compat",
             "version": "v2.0.4",
@@ -53,7 +130,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-11-07 23:38:38"
+            "time": "2016-11-07T23:38:38+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -120,7 +197,7 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2016-03-22 18:20:19"
+            "time": "2016-03-22T18:20:19+00:00"
         },
         {
             "name": "respect/validation",
@@ -184,7 +261,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2015-11-25 20:03:11"
+            "time": "2015-11-25T20:03:11+00:00"
         }
     ],
     "packages-dev": [
@@ -240,7 +317,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -282,7 +359,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2016-10-31 17:19:45"
+            "time": "2016-10-31T17:19:45+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -336,7 +413,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -381,7 +458,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -428,7 +505,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25 06:54:22"
+            "time": "2016-11-25T06:54:22+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -491,7 +568,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21 14:58:47"
+            "time": "2016-11-21T14:58:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -554,7 +631,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-27 16:24:29"
+            "time": "2016-05-27T16:24:29+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -601,7 +678,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -642,7 +719,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -686,7 +763,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -735,7 +812,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15 14:06:22"
+            "time": "2016-11-15T14:06:22+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -809,7 +886,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-02-05 17:50:46"
+            "time": "2016-02-05T17:50:46+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -865,7 +942,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-04-20 14:39:26"
+            "time": "2016-04-20T14:39:26+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -910,7 +987,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2016-02-13 06:45:14"
+            "time": "2016-02-13T06:45:14+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -974,7 +1051,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2016-11-19 09:18:40"
+            "time": "2016-11-19T09:18:40+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1026,7 +1103,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1076,7 +1153,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1143,7 +1220,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1194,7 +1271,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1247,7 +1324,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2015-11-11T19:50:13+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1289,7 +1366,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28 20:34:47"
+            "time": "2015-07-28T20:34:47+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1332,7 +1409,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03 07:35:21"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1387,7 +1464,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-10 10:07:06"
+            "time": "2016-12-10T10:07:06+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1437,7 +1514,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],

--- a/src/Deserializer/Deserializer.php
+++ b/src/Deserializer/Deserializer.php
@@ -9,6 +9,7 @@ class Deserializer implements Contracts\Deserializer
     private $composite;
     private $set;
     private $type_entity;
+    private $money;
     
     public function __construct(Reflector $reflector)
     {
@@ -16,6 +17,7 @@ class Deserializer implements Contracts\Deserializer
         $this->composite = new Deserializer\Composite($this, $reflector);
         $this->set = new Deserializer\Set($this);
         $this->type_entity = new Deserializer\TypeEntity($this, $reflector);
+        $this->money = new Deserializer\Money();
     }
     
     public function deserialize($class, $parameters)
@@ -37,6 +39,9 @@ class Deserializer implements Contracts\Deserializer
         }
         if ($this->is_instance_of($class, Type\AbstractSet::class)) {
             return $this->set;
+        }
+        if ($this->is_instance_of($class, \Money\Money::class)) {
+            return $this->money;
         }
         
         throw new \Exception("No deserializer found for class ".$class);

--- a/src/Deserializer/Deserializer/Money.php
+++ b/src/Deserializer/Deserializer/Money.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace EventSourced\ValueObject\Deserializer\Deserializer;
+
+use EventSourced\ValueObject\Deserializer\Exception;
+
+class Money
+{
+    public function deserialize($class, $serialized)
+    {
+        if (is_array($serialized)) {
+            $serialized = (object)$serialized;
+        }
+
+        try {
+            return new \Money\Money(
+                $serialized->amount,
+                new \Money\Currency($serialized->currency)
+            );
+        } catch (\Exception $e) {
+            throw new Exception($e->getMessage());
+        }
+    }
+}

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -10,12 +10,14 @@ class Serializer implements Contracts\Serializer
     private $single_value;
     private $composite;
     private $set;
+    private $money;
     
     public function __construct(Reflector $reflector)
     {
         $this->single_value = new Serializer\SingleValue();
         $this->composite = new Serializer\Composite($this, $reflector);
         $this->set = new Serializer\Set($this);
+        $this->money = new Serializer\Money();
     }
 
     public function serialize($object)
@@ -37,6 +39,9 @@ class Serializer implements Contracts\Serializer
         }
         if ($this->is_instance_of($class, Type\AbstractSet::class)) {
             return $this->set;
+        }
+        if ($this->is_instance_of($class, \Money\Money::class)) {
+            return $this->money;
         }
         throw new Exception("No serializer found for class '".$class."'");
     }

--- a/src/Serializer/Serializer/Money.php
+++ b/src/Serializer/Serializer/Money.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EventSourced\ValueObject\Serializer\Serializer;
+
+class Money
+{
+    public function serialize(\Money\Money $money)
+    {
+        return [
+            'amount' => $money->getAmount(),
+            'currency' => $money->getCurrency()->getCode()
+        ];
+    }
+}

--- a/src/ValueObject/SampleSellable.php
+++ b/src/ValueObject/SampleSellable.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace EventSourced\ValueObject\ValueObject;
+
+use EventSourced\ValueObject\ValueObject\Type\AbstractComposite;
+use Money\Money;
+
+class SampleSellable extends AbstractComposite
+{
+    protected $name;
+    protected $price;
+
+    public function __construct(
+        NotBlankString $name,
+        Money $price
+    ) {
+        $this->name = $name;
+        $this->price = $price;
+    }
+
+    public function name()
+    {
+        return $this->name;
+    }
+
+    public function price()
+    {
+        return $this->price;
+    }
+}

--- a/test/ValueObject/SampleSellable.php
+++ b/test/ValueObject/SampleSellable.php
@@ -1,0 +1,91 @@
+<?php
+
+use EventSourced\ValueObject\Deserializer\Deserializer;
+use EventSourced\ValueObject\Deserializer\Exception;
+use EventSourced\ValueObject\Reflector\Reflector;
+use EventSourced\ValueObject\Serializer\Serializer;
+use EventSourced\ValueObject\ValueObject\NotBlankString;
+use EventSourced\ValueObject\ValueObject\SampleSellable;
+use Money\Currency;
+use Money\Money;
+
+class SampleSellableTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Serializer
+     */
+    private $serializer;
+
+    /**
+     * @var Deserializer
+     */
+    private $deserializer;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $reflector = new Reflector();
+        $this->serializer = new Serializer($reflector);
+        $this->deserializer = new Deserializer($reflector);
+    }
+
+    public function test_create_sellable_item()
+    {
+        $book = new SampleSellable(
+            new NotBlankString("Adventures"),
+            new Money("15", new Currency('EUR'))
+        );
+
+        $this->assertInstanceOf(SampleSellable::class, $book);
+    }
+
+    public function test_serialize_sellable()
+    {
+        $book = new SampleSellable(
+            new NotBlankString("Adventures"),
+            new Money("15", new Currency('EUR'))
+        );
+
+        $expected = [
+            'name' => 'Adventures',
+            'price' => [
+                'amount' => '15',
+                'currency' => 'EUR'
+            ]
+        ];
+
+        $serialized = $this->serializer->serialize($book);
+        $this->assertInternalType('array', $serialized);
+        $this->assertEquals($expected, $serialized);
+    }
+
+    public function test_deserialize_sellable()
+    {
+        $serialized = [
+            'name' => 'Adventures',
+            'price' => [
+                'amount' => '15',
+                'currency' => 'EUR'
+            ]
+        ];
+
+        $book = $this->deserializer->deserialize(SampleSellable::class, $serialized);
+        $this->assertInstanceOf(SampleSellable::class, $book);
+    }
+
+    public function test_exception_should_be_thrown()
+    {
+        $this->expectException(Exception::class);
+        
+        $serialized = [
+            'name' => 'Adventures',
+            'price' => [
+                'amount' => '15',
+                'currency' => null
+            ]
+        ];
+
+        $this->deserializer->deserialize(SampleSellable::class, $serialized);
+    }
+}


### PR DESCRIPTION
This PR adds Money value object support by exposing [moneyphp/money](https://github.com/moneyphp/money) library.

Since Money class has been already "finalized" Serializer and Deserializer classes looks pretty straightforward.
On the other hand this approach goes off the general idea by registering implementations of serializer/deserializer rather then contracts.

It might be introducing Money interface and having wrapper around this library makes more sense but it looks a bit overhead.

Also SampleSellable class was added in order to test the serialization/deserialization of composites having Money object as a dependency.

