### PR TITLE
Nullable composites.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,27 @@ class GPSCoordinates extends AbstractComposite
 ```
 So it's simply just a holder for a bunch of valueobjects. If you want to run any validation across value objects, you should do it in the constructor. The base class takes care of the "equals" method, so you don't have to worry about that.
 
+### Nullable Composite
+Making a nullable single value is easy, making a nullable composite is harder, and really should be used as a last resort. That said, it's useful to have.
+
+To create a nullable composite, you set all the defaults values for the composite to null. That's it.
+
+```php
+<?php namespace EventSourced\ValueObject\ValueObject;
+
+class NullableGPSCoordinates extends GPSCoordinates
+{
+    public function __construct(Coordinate $latitude=null, Coordinate $longitude=null)
+    {
+        $this->latitude = $latitude;
+        $this->longitude = $longitude;
+    }
+}
+
+```
+**NB:**
+When you serialize an instance of the above, and all the values are null, you will get a null response, not an array with keys and values, just null.
+
 ### Collections
 Sometimes you'll want to have a collection of ValueObjects. Now, you shouldn't use a standard array, because you want strong typing (also the deserializer has to know what type of ValueObject is in the collection, more on that later). That's why we created a simple helper class for creating strongly typed collections of ValueObjects.
 ```php

--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ class NullableGPSCoordinates extends GPSCoordinates
         $this->longitude = $longitude;
     }
 }
-
 ```
+
+Each composite offers a `is_null()` method, so you can easily check if the VO is actually null.
+
 **NB:**
 When you serialize an instance of the above, and all the values are null, you will get a null response, not an array with keys and values, just null.
 

--- a/src/Deserializer/Deserializer/Composite.php
+++ b/src/Deserializer/Deserializer/Composite.php
@@ -46,20 +46,14 @@ class Composite
         return $this->reflector->call_constructor($class, $deserialized_parameters);
     }
 
-    private function is_nullable_parameter(ReflectionParameter $parameter)
-    {
-        return ($parameter->isOptional() && $parameter->getDefaultValue() == null);
-    }
-
-
     private function make_parameter($parameter, $serialized)
     {
-        if ($this->is_nullable_parameter($parameter)) {
-            return null;
-        }
-
         $name = $parameter->getName();
         $parameter_class = $parameter->getClass()->getName();
+
+        if ($this->is_nullable_parameter($parameter) && is_null($serialized)) {
+            return null;
+        }
 
         if (!property_exists($serialized, $name)) {
             throw new Exception(["Property '$name' is missing"]);
@@ -68,5 +62,10 @@ class Composite
         return $this->deserializer->deserialize(
             $parameter_class, $serialized->$name
         );
+    }
+
+    private function is_nullable_parameter(ReflectionParameter $parameter)
+    {
+        return ($parameter->isOptional() && $parameter->getDefaultValue() === null);
     }
 }

--- a/src/Deserializer/Deserializer/Composite.php
+++ b/src/Deserializer/Deserializer/Composite.php
@@ -30,16 +30,12 @@ class Composite
         foreach ($parameters as $parameter) {
             $name = $parameter->getName();
 
-            if ($this->is_nullable_parameter($parameter)) {
-                $deserialized_parameters[$name] = null;
-            } else {
-                try {
-                    $deserialized_parameters[$name] = $this->make_parameter($parameter, $serialized);
-                } catch (AssertException $e) {
-                    $errors[$name] = $e->error_messages();
-                } catch (Exception $e) {
-                    $errors[$name] = $e->error_messages();
-                }
+            try {
+                $deserialized_parameters[$name] = $this->make_parameter($parameter, $serialized);
+            } catch (AssertException $e) {
+                $errors[$name] = $e->error_messages();
+            } catch (Exception $e) {
+                $errors[$name] = $e->error_messages();
             }
         }
 
@@ -58,6 +54,10 @@ class Composite
 
     private function make_parameter($parameter, $serialized)
     {
+        if ($this->is_nullable_parameter($parameter)) {
+            return null;
+        }
+
         $name = $parameter->getName();
         $parameter_class = $parameter->getClass()->getName();
 

--- a/src/Deserializer/Deserializer/Composite.php
+++ b/src/Deserializer/Deserializer/Composite.php
@@ -16,7 +16,7 @@ class Composite
         $this->deserializer = $deserializer;
         $this->reflector = $reflector;
     }
-    
+
     public function deserialize($class, $serialized)
     {
         if (is_array($serialized)) {
@@ -46,20 +46,14 @@ class Composite
         return $this->reflector->call_constructor($class, $deserialized_parameters);
     }
 
-    private function is_nullable_parameter(ReflectionParameter $parameter)
-    {
-        return ($parameter->isOptional() && $parameter->getDefaultValue() == null);
-    }
-
-
     private function make_parameter($parameter, $serialized)
     {
-        if ($this->is_nullable_parameter($parameter)) {
-            return null;
-        }
-
         $name = $parameter->getName();
         $parameter_class = $parameter->getClass()->getName();
+
+        if ($this->is_nullable_parameter($parameter) && is_null($serialized)) {
+            return null;
+        }
 
         if (!property_exists($serialized, $name)) {
             throw new Exception(["Property '$name' is missing"]);
@@ -68,5 +62,10 @@ class Composite
         return $this->deserializer->deserialize(
             $parameter_class, $serialized->$name
         );
+    }
+
+    private function is_nullable_parameter(ReflectionParameter $parameter)
+    {
+        return ($parameter->isOptional() && $parameter->getDefaultValue() === null);
     }
 }

--- a/src/Serializer/Serializer/Composite.php
+++ b/src/Serializer/Serializer/Composite.php
@@ -39,8 +39,9 @@ class Composite
 
     private function all_properties_are_null($serialized)
     {
-        return count(array_filter($serialized), function($value){
-            return $value !== null;
-        }) == 0;
+        $no_nulls = array_filter($serialized, function($var){
+            return !is_null($var);
+        } );
+        return count($no_nulls) == 0;
     }
 }

--- a/src/Serializer/Serializer/Composite.php
+++ b/src/Serializer/Serializer/Composite.php
@@ -1,8 +1,5 @@
-<?php
+<?php namespace EventSourced\ValueObject\Serializer\Serializer;
 
-namespace EventSourced\ValueObject\Serializer\Serializer;
-
-use EventSourced\ValueObject\Serializer\Exception;
 use EventSourced\ValueObject\Serializer\Serializer;
 use EventSourced\ValueObject\ValueObject\Type\AbstractComposite;
 use EventSourced\ValueObject\Serializer\Reflector;
@@ -27,10 +24,21 @@ class Composite
             $name = $parameter->getName();
             $value_object = $parameter->getValue($object);
             if (!$value_object) {
-                throw new Exception("Property '$name' is null, cannot encode. Please check a value is assigned in the constructor.");
+                $serialized[$name] = null;
+            } else {
+                $serialized[$name] = $this->serializer->serialize($value_object);
             }
-            $serialized[$name] = $this->serializer->serialize($value_object);
         }
+
+        if ($this->all_properties_are_null($serialized)) {
+            return null;
+        }
+
 		return $serialized;
+    }
+
+    private function all_properties_are_null($serialized)
+    {
+        return count(array_filter($serialized)) == 0;
     }
 }

--- a/src/Serializer/Serializer/Composite.php
+++ b/src/Serializer/Serializer/Composite.php
@@ -39,6 +39,9 @@ class Composite
 
     private function all_properties_are_null($serialized)
     {
-        return count(array_filter($serialized)) == 0;
+        $no_nulls = array_filter($serialized, function($var){
+            return !is_null($var);
+        } );
+        return count($no_nulls) == 0;
     }
 }

--- a/src/Serializer/Serializer/Composite.php
+++ b/src/Serializer/Serializer/Composite.php
@@ -39,6 +39,8 @@ class Composite
 
     private function all_properties_are_null($serialized)
     {
-        return count(array_filter($serialized)) == 0;
+        return count(array_filter($serialized), function($value){
+            return $value !== null;
+        }) == 0;
     }
 }

--- a/src/ValueObject/NullableGPSCoordinates.php
+++ b/src/ValueObject/NullableGPSCoordinates.php
@@ -1,0 +1,11 @@
+<?php namespace EventSourced\ValueObject\ValueObject;
+
+class NullableGPSCoordinates extends GPSCoordinates
+{
+    public function __construct(Coordinate $latitude=null, Coordinate $longitude=null)
+    {
+        $this->latitude = $latitude;
+        $this->longitude = $longitude;
+    }
+}
+

--- a/src/ValueObject/Type/AbstractComposite.php
+++ b/src/ValueObject/Type/AbstractComposite.php
@@ -13,8 +13,12 @@ abstract class AbstractComposite extends AbstractValueObject
             return $result;
         }
         foreach ($this as $key=>$valueobject) {
-            $result = $result && 
-                $valueobject->equals($other_valueobject->$key);
+
+            if ($valueobject === null) {
+                $result = $result && ($other_valueobject->$key === null);
+            } else {
+                $result = $result && $valueobject->equals($other_valueobject->$key);
+            }
         }
 		return $result;
 	}

--- a/src/ValueObject/Type/AbstractComposite.php
+++ b/src/ValueObject/Type/AbstractComposite.php
@@ -8,27 +8,34 @@ abstract class AbstractComposite extends AbstractValueObject
 {  
     public function equals(ValueObject $other_valueobject) 
 	{
-        $result = $this->is_same_class($other_valueobject);
-        if (!$result) {
-            return $result;
+        if (!$this->is_same_class($other_valueobject)) {
+            return false;
         }
-        foreach ($this as $key=>$valueobject) {
 
-            if ($valueobject === null) {
-                $result = $result && ($other_valueobject->$key === null);
-            } else {
-                $result = $result && $valueobject->equals($other_valueobject->$key);
+        foreach ($this as $key=>$valueobject) {
+            if (!$this->vos_are_eqauls($valueobject, $other_valueobject->$key)) {
+                return false;
             }
         }
-		return $result;
+		return true;
 	}
+
+	private function vos_are_eqauls($valueobect_a, $valueobect_b)
+    {
+        if ($valueobect_a === null) {
+            return ($valueobect_b === null);
+        }
+
+        return $valueobect_a->equals($valueobect_b);
+    }
 
     public function is_null()
     {
-        $result = true;
         foreach ($this as $key=>$valueobject) {
-            $result = $result && ($valueobject === null);
+            if ($valueobject !== null) {
+                return false;
+            }
         }
-        return $result;
+        return true;
     }
 }

--- a/src/ValueObject/Type/AbstractComposite.php
+++ b/src/ValueObject/Type/AbstractComposite.php
@@ -5,9 +5,9 @@ namespace EventSourced\ValueObject\ValueObject\Type;
 use EventSourced\ValueObject\Contracts\ValueObject;
 
 abstract class AbstractComposite extends AbstractValueObject
-{  
-    public function equals(ValueObject $other_valueobject) 
-	{
+{
+    public function equals(ValueObject $other_valueobject)
+    {
         if (!$this->is_same_class($other_valueobject)) {
             return false;
         }
@@ -17,10 +17,10 @@ abstract class AbstractComposite extends AbstractValueObject
                 return false;
             }
         }
-		return true;
-	}
+        return true;
+    }
 
-	private function vos_are_equal($valueobect_a, $valueobect_b)
+    private function vos_are_equal($valueobect_a, $valueobect_b)
     {
         if ($valueobect_a === null) {
             return ($valueobect_b === null);

--- a/src/ValueObject/Type/AbstractComposite.php
+++ b/src/ValueObject/Type/AbstractComposite.php
@@ -22,4 +22,13 @@ abstract class AbstractComposite extends AbstractValueObject
         }
 		return $result;
 	}
+
+    public function is_null()
+    {
+        $result = true;
+        foreach ($this as $key=>$valueobject) {
+            $result = $result && ($valueobject === null);
+        }
+        return $result;
+    }
 }

--- a/src/ValueObject/Type/AbstractComposite.php
+++ b/src/ValueObject/Type/AbstractComposite.php
@@ -13,14 +13,14 @@ abstract class AbstractComposite extends AbstractValueObject
         }
 
         foreach ($this as $key=>$valueobject) {
-            if (!$this->vos_are_eqauls($valueobject, $other_valueobject->$key)) {
+            if (!$this->vos_are_equal($valueobject, $other_valueobject->$key)) {
                 return false;
             }
         }
 		return true;
 	}
 
-	private function vos_are_eqauls($valueobect_a, $valueobect_b)
+	private function vos_are_equal($valueobect_a, $valueobect_b)
     {
         if ($valueobect_a === null) {
             return ($valueobect_b === null);

--- a/test/Serializer/NullableComposite.php
+++ b/test/Serializer/NullableComposite.php
@@ -1,0 +1,43 @@
+<?php namespace EventSourced\ValueObject\Test\ValueObject;
+
+use EventSourced\ValueObject\Extensions\ExtensionRepository;
+use EventSourced\ValueObject\ValueObject\Coordinate;
+use EventSourced\ValueObject\ValueObject\NullableGPSCoordinates;
+use EventSourced\ValueObject\Reflector\Reflector;
+
+class TestNullableComposite extends \PHPUnit_Framework_TestCase
+{
+    private $gps;
+    private $deserialized = null;
+    private $serializer;
+    private $deserializer;
+
+    public function setUp()
+    {
+        $reflector = new Reflector();
+        $extensions = new ExtensionRepository();
+        $this->serializer = new \EventSourced\ValueObject\Serializer\Serializer($reflector, $extensions);
+        $this->deserializer = new \EventSourced\ValueObject\Deserializer\Deserializer($reflector, $extensions);
+        $this->gps = new NullableGPSCoordinates();
+        parent::setUp();
+    }
+
+    public function test_serialize()
+    {
+        $this->assertEquals($this->deserialized, $this->serializer->serialize($this->gps));
+    }
+
+    public function test_deserialize()
+    {
+        $gps = $this->deserializer->deserialize(NullableGPSCoordinates::class, $this->deserialized);
+        $this->assertTrue($this->gps->equals($gps));
+    }
+
+    public function test_can_use_with_real_values()
+    {
+        $deserialized = ['latitude'=>23.9, 'longitude'=>90.0];
+        $gps = new NullableGPSCoordinates(new Coordinate(23.9),  new Coordinate(90.0));
+
+        $this->assertEquals($deserialized, $this->serializer->serialize($gps));
+    }
+}

--- a/test/Serializer/NullableComposite.php
+++ b/test/Serializer/NullableComposite.php
@@ -27,9 +27,9 @@ class TestNullableComposite extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->deserialized, $this->serializer->serialize($this->gps));
     }
 
-    public function test_deserialize()
+    public function test_deserialize_null()
     {
-        $gps = $this->deserializer->deserialize(NullableGPSCoordinates::class, $this->deserialized);
+        $gps = $this->deserializer->deserialize(NullableGPSCoordinates::class, null);
         $this->assertTrue($this->gps->equals($gps));
     }
 
@@ -37,6 +37,14 @@ class TestNullableComposite extends \PHPUnit_Framework_TestCase
     {
         $deserialized = ['latitude'=>23.9, 'longitude'=>90.0];
         $gps = new NullableGPSCoordinates(new Coordinate(23.9),  new Coordinate(90.0));
+
+        $this->assertEquals($deserialized, $this->serializer->serialize($gps));
+    }
+    
+    public function test_zero_values_are_not_treated_as_null()
+    {
+        $deserialized = ['latitude'=>0, 'longitude'=>0.0];
+        $gps = new NullableGPSCoordinates(new Coordinate(0),  new Coordinate(0));
 
         $this->assertEquals($deserialized, $this->serializer->serialize($gps));
     }

--- a/test/Serializer/SerializerNotFound.php
+++ b/test/Serializer/SerializerNotFound.php
@@ -21,11 +21,4 @@ class TestSerializerNotFound extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(Serializer\Exception::class, "No serializer found for class 'stdClass'");
         $this->serializer->serialize(new \stdClass());
     }
-
-    public function test_fails_if_VO_property_is_blank()
-    {
-        $this->setExpectedException(Serializer\Exception::class, "Property 'no_value' is null, cannot encode. Please check a value is assigned in the constructor.");
-        $VO = new \Test\Serializer\BlankPropertyVO( Uuid::generate());
-        $this->serializer->serialize($VO);
-    }
 }

--- a/test/ValueObject/NullableGPSCoordinates.php
+++ b/test/ValueObject/NullableGPSCoordinates.php
@@ -1,0 +1,27 @@
+<?php namespace EventSourced\ValueObject\Test\ValueObject;
+
+use EventSourced\ValueObject\ValueObject\NullableGPSCoordinates;
+use EventSourced\ValueObject\ValueObject\Coordinate;
+
+class TestNullableGPSCoordinates extends \PHPUnit_Framework_TestCase
+{
+    private $gps;
+
+    public function setUp()
+    {
+        $this->gps = new NullableGPSCoordinates();
+        parent::setUp();
+    }
+
+    public function test_is_null_when_null()
+    {
+        $gps = new NullableGPSCoordinates();
+        $this->assertTrue($gps->is_null());
+    }
+
+    public function test_is_null_when_not_not_null()
+    {
+        $gps = new NullableGPSCoordinates(new Coordinate(23.9),  new Coordinate(83.0));
+        $this->assertFalse($gps->is_null());
+    }
+}


### PR DESCRIPTION
We can now have composite valueobjects that are treated as null. This allows us to serialize and deserialize null values into a null version of a composite object, useful when the object is optional and not mandatory.

See the `readme` for more details.